### PR TITLE
Proper Entity Flags

### DIFF
--- a/WGEF-Abstraction/src/main/java/io/github/invvk/wgef/abstraction/flags/WGEFlags.java
+++ b/WGEF-Abstraction/src/main/java/io/github/invvk/wgef/abstraction/flags/WGEFlags.java
@@ -64,6 +64,12 @@ public final class WGEFlags {
     public final static SetFlag<EntityType> ALLOW_ENTITY_PLACE = new SetFlag<EntityType>("allow-entity-place", new EntityTypeFlag(null));
     public final static SetFlag<EntityType> DENY_ENTITY_PLACE = new SetFlag<EntityType>("deny-entity-place", new EntityTypeFlag(null));
 
+    public final static SetFlag<EntityType> ALLOW_ENTITY_DAMAGE = new SetFlag<EntityType>("allow-entity-damage", new EntityTypeFlag(null));
+    public final static SetFlag<EntityType> DENY_ENTITY_DAMAGE = new SetFlag<EntityType>("deny-entity-damage", new EntityTypeFlag(null));
+
+    public final static SetFlag<EntityType> ALLOW_ENTITY_DESTROY = new SetFlag<EntityType>("allow-entity-destroy", new EntityTypeFlag(null));
+    public final static SetFlag<EntityType> DENY_ENTITY_DESTROY = new SetFlag<EntityType>("deny-entity-destroy", new EntityTypeFlag(null));
+
     public final static BooleanFlag DISABLE_COLLISION = new BooleanFlag("disable-collision");
 
     public static Set<Flag<?>> values() {

--- a/WGEF-Core/src/main/java/io/github/invvk/wgef/WGPluginManager.java
+++ b/WGEF-Core/src/main/java/io/github/invvk/wgef/WGPluginManager.java
@@ -78,6 +78,10 @@ public class WGPluginManager implements IManager {
         registry.register(WGEFlags.VILLAGER_TRADE);
         registry.register(WGEFlags.ALLOW_ENTITY_PLACE);
         registry.register(WGEFlags.DENY_ENTITY_PLACE);
+        registry.register(WGEFlags.ALLOW_ENTITY_DAMAGE);
+        registry.register(WGEFlags.DENY_ENTITY_DAMAGE);
+        registry.register(WGEFlags.ALLOW_ENTITY_DESTROY);
+        registry.register(WGEFlags.DENY_ENTITY_DESTROY);
         registry.register(WGEFlags.DISABLE_COLLISION);
 
         this.dependency();
@@ -126,7 +130,8 @@ public class WGPluginManager implements IManager {
                 new ItemListener(this.plugin),
                 new SpeedListener(this.plugin),
                 new VillagerTradeListener(this.plugin),
-                new EntityPlaceListener(this.plugin));
+                new EntityPlaceListener(this.plugin),
+                new EntityBreakListener(this.plugin));
 
         if (!plugin.getConfig().getBoolean("disable-block-flag-patch"))
             registerEvents(new BlockListenerPatch());

--- a/WGEF-Core/src/main/java/io/github/invvk/wgef/listeners/EntityBreakListener.java
+++ b/WGEF-Core/src/main/java/io/github/invvk/wgef/listeners/EntityBreakListener.java
@@ -1,0 +1,68 @@
+package io.github.invvk.wgef.listeners;
+
+import org.bukkit.Location;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.bukkit.event.*;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import com.sk89q.worldguard.bukkit.event.Handleable;
+import com.sk89q.worldguard.bukkit.event.entity.DamageEntityEvent;
+import com.sk89q.worldguard.bukkit.event.entity.DestroyEntityEvent;
+import com.sk89q.worldguard.protection.ApplicableRegionSet;
+import com.sk89q.worldguard.protection.flags.SetFlag;
+import io.github.invvk.wgef.WGEFPlugin;
+import io.github.invvk.wgef.abstraction.WGEFUtils;
+import io.github.invvk.wgef.abstraction.flags.WGEFlags;
+
+import java.util.Set;
+
+public final class EntityBreakListener implements Listener {
+
+    private final WGEFPlugin plugin;
+
+    public EntityBreakListener(WGEFPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onEntityDamage(DamageEntityEvent e) {
+        if (!(e.getOriginalEvent() instanceof EntityDamageByEntityEvent original) || !(original.getDamager() instanceof Player damager)) {
+            return;
+        }
+
+        handleEntityEvent(WGEFlags.ALLOW_ENTITY_DAMAGE, WGEFlags.DENY_ENTITY_DAMAGE, damager, e, e.getEntity().getType(), e.getTarget());
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onEntityDestroy(DestroyEntityEvent e) {
+        final var cause = e.getCause().getFirstPlayer();
+        if (cause == null) {
+            return;
+        }
+
+        handleEntityEvent(WGEFlags.ALLOW_ENTITY_DESTROY, WGEFlags.DENY_ENTITY_DESTROY, cause, e, e.getEntity().getType(), e.getTarget());
+    }
+
+    private void handleEntityEvent(SetFlag<EntityType> allowFlag, SetFlag<EntityType> denyFlag, Player playerWhoPlaced, Cancellable event, EntityType entityType, Location location) {
+        ApplicableRegionSet regions = plugin.getFork().getRegionContainer().createQuery().getApplicableRegions(location);
+
+        Set<EntityType> allowed = WGEFUtils.queryValue(playerWhoPlaced, location.getWorld(), regions.getRegions(), allowFlag);
+        if (allowed != null) {
+            if (!allowed.contains(entityType)) {
+                event.setCancelled(true);
+                return;
+            } else if (event instanceof Handleable handleable) {
+                handleable.setResult(Event.Result.ALLOW);
+                return;
+            }
+        }
+
+
+        Set<EntityType> denied = WGEFUtils.queryValue(playerWhoPlaced, location.getWorld(), regions.getRegions(), denyFlag);
+        if (denied != null && denied.contains(entityType)) {
+            event.setCancelled(true);
+        }
+    }
+
+}

--- a/WGEF-Core/src/main/java/io/github/invvk/wgef/listeners/EntityPlaceListener.java
+++ b/WGEF-Core/src/main/java/io/github/invvk/wgef/listeners/EntityPlaceListener.java
@@ -58,7 +58,15 @@ public class EntityPlaceListener implements Listener {
             return;
         }
 
-        e.setResult(resolvePlaceResult(original.getPlayer(), e.getEffectiveType(), e.getTarget()));
+        final var result = resolvePlaceResult(original.getPlayer(), e.getEffectiveType(), e.getTarget());
+
+        if (result != Event.Result.DEFAULT) {
+            e.setResult(result);
+
+            if (result == Event.Result.DENY) {
+                original.getPlayer().updateInventory();
+            }
+        }
     }
 
     private Event.Result resolvePlaceResult(final Player player, final EntityType type, final Location location) {
@@ -74,7 +82,7 @@ public class EntityPlaceListener implements Listener {
             return Event.Result.DENY;
         }
 
-        return Event.Result.DENY;
+        return Event.Result.DEFAULT;
     }
 
 }

--- a/WGEF-Core/src/main/java/io/github/invvk/wgef/listeners/EntityPlaceListener.java
+++ b/WGEF-Core/src/main/java/io/github/invvk/wgef/listeners/EntityPlaceListener.java
@@ -1,18 +1,19 @@
 package io.github.invvk.wgef.listeners;
 
+import com.sk89q.worldguard.bukkit.event.Handleable;
+import com.sk89q.worldguard.bukkit.event.entity.SpawnEntityEvent;
 import com.sk89q.worldguard.protection.ApplicableRegionSet;
 import io.github.invvk.wgef.WGEFPlugin;
 import io.github.invvk.wgef.abstraction.WGEFUtils;
 import io.github.invvk.wgef.abstraction.flags.WGEFlags;
-import org.bukkit.entity.Entity;
+import org.bukkit.Location;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
-import org.bukkit.event.Cancellable;
-import org.bukkit.event.EventHandler;
-import org.bukkit.event.EventPriority;
-import org.bukkit.event.Listener;
+import org.bukkit.event.*;
+import org.bukkit.event.block.Action;
 import org.bukkit.event.entity.EntityPlaceEvent;
 import org.bukkit.event.hanging.HangingPlaceEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
 
 import java.util.Set;
 
@@ -26,26 +27,41 @@ public class EntityPlaceListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST)
     public void onEntityPlacement(EntityPlaceEvent e) {
-        handleEntityEvent(e.getPlayer(), e, e.getEntity());
+        handleEntityEvent(e.getPlayer(), e, e.getEntity().getType(), e.getEntity().getLocation());
     }
 
     @EventHandler(priority = EventPriority.LOWEST)
     public void onEntityHang(HangingPlaceEvent e) {
-        handleEntityEvent(e.getPlayer(), e, e.getEntity());
+        handleEntityEvent(e.getPlayer(), e, e.getEntity().getType(), e.getEntity().getLocation());
     }
 
-    private void handleEntityEvent(Player playerWhoPlaced, Cancellable event, Entity entity) {
-        EntityType entityType = entity.getType();
-        ApplicableRegionSet regions = plugin.getFork().getRegionContainer().createQuery().getApplicableRegions(entity.getLocation());
-
-        Set<EntityType> allowedEntityPlacements = WGEFUtils.queryValue(playerWhoPlaced, entity.getWorld(), regions.getRegions(), WGEFlags.ALLOW_ENTITY_PLACE);
-        if (allowedEntityPlacements != null && !allowedEntityPlacements.contains(entity.getType())) {
-            event.setCancelled(true);
-            playerWhoPlaced.updateInventory();
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onEntitySpawn(SpawnEntityEvent e) {
+        if (!(e.getOriginalEvent() instanceof PlayerInteractEvent original) || original.getAction() != Action.RIGHT_CLICK_BLOCK) {
+            return;
         }
 
-        Set<EntityType> deniedEntityPlacements = WGEFUtils.queryValue(playerWhoPlaced, entity.getWorld(), regions.getRegions(), WGEFlags.DENY_ENTITY_PLACE);
-        if (deniedEntityPlacements != null && deniedEntityPlacements.contains(entity.getType())) {
+        handleEntityEvent(original.getPlayer(), e, e.getEffectiveType(), e.getTarget());
+    }
+
+    private void handleEntityEvent(Player playerWhoPlaced, Cancellable event, EntityType entityType, Location location) {
+        ApplicableRegionSet regions = plugin.getFork().getRegionContainer().createQuery().getApplicableRegions(location);
+
+        Set<EntityType> allowedEntityPlacements = WGEFUtils.queryValue(playerWhoPlaced, location.getWorld(), regions.getRegions(), WGEFlags.ALLOW_ENTITY_PLACE);
+        if (allowedEntityPlacements != null) {
+            if (!allowedEntityPlacements.contains(entityType)) {
+                event.setCancelled(true);
+                playerWhoPlaced.updateInventory();
+                return;
+            } else if (event instanceof Handleable handleable) {
+                handleable.setResult(Event.Result.ALLOW);
+                return;
+            }
+        }
+
+
+        Set<EntityType> deniedEntityPlacements = WGEFUtils.queryValue(playerWhoPlaced, location.getWorld(), regions.getRegions(), WGEFlags.DENY_ENTITY_PLACE);
+        if (deniedEntityPlacements != null && deniedEntityPlacements.contains(entityType)) {
             event.setCancelled(true);
             playerWhoPlaced.updateInventory();
         }


### PR DESCRIPTION
This PR 
- fixes the functionality of the `allow-entity-place` and `deny-entity-place` flags.
- adds additional flags:
  - `allow-entity-damage` allows players to damage the listed entities
  - `deny-entity-damage` prevents players from damaging the listed entities
  - `allow-entity-destroy` allows players to destroy the listed entities
  - `deny-entity-destroy` prevents players from destroying the listed entities